### PR TITLE
Don't hardcode localhost for the API url on the channel

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -210,7 +210,7 @@ export default {
   methods: {
     initWeatherChannel(callback) {
       this.$http
-        .get("//localhost:8600/api/init")
+        .get("api/init")
         .then((resp) => {
           const data = resp.data;
           if (!data) return;
@@ -256,7 +256,7 @@ export default {
 
     getWeather() {
       this.$http
-        .get("//localhost:8600/api/weather")
+        .get("api/weather")
         .then((resp) => {
           const data = resp.data;
           if (!data) return;
@@ -277,7 +277,7 @@ export default {
 
     getSurroundingWeather() {
       this.$http
-        .get("//localhost:8600/api/weather/surrounding")
+        .get("api/weather/surrounding")
         .then((resp) => {
           const data = resp.data;
           if (!data || !data.observations || !data.observations.length) return;
@@ -294,7 +294,7 @@ export default {
       if (!this.showMBHighLowSetting) return;
 
       this.$http
-        .get("//localhost:8600/api/weather/mb_highlow")
+        .get("api/weather/mb_highlow")
         .then((resp) => {
           const data = resp.data;
           if (!data || !data.values || !data.values.length) return;

--- a/src/components/playlist.vue
+++ b/src/components/playlist.vue
@@ -2,7 +2,7 @@
   <audio
     id="playlist_audio"
     v-if="currentTrack"
-    :src="`//localhost:8600/${currentTrack}`"
+    :src="`${playlistURL}${currentTrack}`"
     autoplay
     volume="0.5"
     @ended="selectRandomTrackFromPlaylist"
@@ -11,6 +11,10 @@
 </template>
 
 <script>
+const BASE_URL = `http://${window.location.hostname}`;
+const BASE_PORT = window.location.port;
+const API_URL = `${BASE_URL}:${BASE_PORT}/`;
+
 export default {
   name: "Playlist",
   props: {
@@ -28,6 +32,12 @@ export default {
 
   data() {
     return { currentTrack: null };
+  },
+
+  computed: {
+    playlistURL() {
+      return API_URL;
+    },
   },
 
   mounted() {

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,11 @@ import App from "./App.vue";
 import axios from "axios";
 import VueAxios from "vue-axios";
 
+const BASE_URL = `http://${window.location.hostname}`;
+const BASE_PORT = window.location.port;
+const API_URL = `${BASE_URL}:${BASE_PORT}/`;
+
 const app = createApp(App);
-app.use(VueAxios, axios);
+const weatherAxios = axios.create({ url: API_URL });
+app.use(VueAxios, weatherAxios);
 app.mount("#app");


### PR DESCRIPTION
This addresses an issue seen in #152 when you access the app from anything other than `localhost`. Due to the previous version hardcoding the API calls to go to `localhost` you are unable to retrieve the data from the API.