### PR TITLE
condition-truncation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "retro-env-can-weather-chan",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/conditions.vue
+++ b/src/components/conditions.vue
@@ -24,6 +24,7 @@
 <script>
 import { parseISO, format } from "date-fns";
 import { calculateWindChillNumber } from "../js/windChill";
+import conditionmixin from "../mixins/condition.mixin";
 
 export default {
   name: "Conditions",
@@ -32,6 +33,8 @@ export default {
     observed: String,
     conditions: Object,
   },
+
+  mixins: [conditionmixin],
 
   computed: {
     titleString() {
@@ -104,13 +107,6 @@ export default {
       for (let i = 0; i < paddingToAdd; i++) paddingString += `&nbsp;`;
 
       return !isFront ? `${val}${paddingString}` : `${paddingString}${val}`;
-    },
-
-    truncateConditions(condition) {
-      if (!condition) return "";
-      if (condition.includes("with")) condition = condition.split(" with")[0];
-      if (condition.includes("and")) condition = condition.split(" and")[0];
-      return `${condition.slice(0, 16)}`;
     },
   },
 };

--- a/src/components/conditions.vue
+++ b/src/components/conditions.vue
@@ -46,9 +46,7 @@ export default {
     },
 
     currentCondition() {
-      const condition = this.conditions.condition;
-      if (condition.includes("thunderstorms with")) return "Thunderstorms";
-      return `${condition.slice(0, 16)}`;
+      return this.truncateConditions(this.conditions?.condition);
     },
 
     temperature() {
@@ -106,6 +104,13 @@ export default {
       for (let i = 0; i < paddingToAdd; i++) paddingString += `&nbsp;`;
 
       return !isFront ? `${val}${paddingString}` : `${paddingString}${val}`;
+    },
+
+    truncateConditions(condition) {
+      if (!condition) return "";
+      if (condition.includes("with")) condition = condition.split(" with")[0];
+      if (condition.includes("and")) condition = condition.split(" and")[0];
+      return `${condition.slice(0, 16)}`;
     },
   },
 };

--- a/src/components/surrounding.vue
+++ b/src/components/surrounding.vue
@@ -20,6 +20,7 @@ const PAGE_CHANGE_FREQUENCY = 15 * 1000;
 
 import { format, parseISO } from "date-fns";
 import { EventBus } from "../js/EventBus";
+import conditionmixin from "../mixins/condition.mixin";
 
 export default {
   name: "Surrounding",
@@ -31,6 +32,8 @@ export default {
       default: () => [],
     },
   },
+
+  mixins: [conditionmixin],
 
   computed: {
     observationsUnavailable() {
@@ -92,8 +95,7 @@ export default {
     },
 
     trimCondition(val) {
-      let squishedVal = val?.replace(/shower/g, "");
-      return squishedVal?.slice(0, 13);
+      return this.truncateConditions(val);
     },
 
     padString(val, minLength, isFront) {

--- a/src/mixins/condition.mixin.js
+++ b/src/mixins/condition.mixin.js
@@ -1,0 +1,12 @@
+export default {
+  name: "condition.mixin",
+  methods: {
+    truncateConditions(condition) {
+      if (!condition) return "";
+
+      if (condition.includes("with")) condition = condition.split(" with")[0];
+      if (condition.includes("and")) condition = condition.split(" and")[0];
+      return `${condition.slice(0, 16)}`;
+    },
+  },
+};

--- a/tests/conditions.spec.js
+++ b/tests/conditions.spec.js
@@ -21,8 +21,17 @@ test("observedFormatted: is computed properly", (done) => {
 test("currentCondition: is computed properly", (done) => {
   expect(vm.currentCondition).toBe("Partly Cloudy");
 
-  vm.conditions.condition = "thunderstorms with heavy rain shower";
+  vm.conditions.condition = "Thunderstorms with heavy rain shower";
   expect(vm.currentCondition).toBe("Thunderstorms");
+
+  vm.conditions.condition = "snow and freezing rain";
+  expect(vm.currentCondition).toBe("snow");
+
+  vm.conditions.condition = "light rainshower";
+  expect(vm.currentCondition).toBe("light rainshower");
+
+  vm.conditions.condition = "freezing rain";
+  expect(vm.currentCondition).toBe("freezing rain");
   done();
 });
 

--- a/tests/surrounding.spec.js
+++ b/tests/surrounding.spec.js
@@ -119,7 +119,7 @@ test("padTitle: makes sure a city name is always 13 characters", (done) => {
   done();
 });
 
-test("trimCondition: makes sure condition string is only 13 characters", (done) => {
+test("trimCondition: makes sure condition string is only 16 characters", (done) => {
   const conditionA = vm.trimCondition("sunny");
   expect(conditionA).toBe("sunny");
 
@@ -127,7 +127,7 @@ test("trimCondition: makes sure condition string is only 13 characters", (done) 
   expect(conditionB).toBe("mostly cloudy");
 
   const conditionC = vm.trimCondition("thunderstorm with light rainshower");
-  expect(conditionC).toBe("thunderstorm ");
+  expect(conditionC).toBe("thunderstorm");
 
   done();
 });
@@ -137,7 +137,7 @@ test("trimCondition: replaces 'shower' with a blank string", (done) => {
   expect(conditionA).toBe("sunny");
 
   const conditionB = vm.trimCondition("light rainshower");
-  expect(conditionB).toBe("light rain");
+  expect(conditionB).toBe("light rainshower");
 
   done();
 });


### PR DESCRIPTION
### Conditions Truncation

This will do a better job at truncating conditions so they don't get cut off weirdly. For example, it will first remove any "and x" or "with x" and then truncate the string to 16 characters after that.