### PR TITLE
feat(forecast): turn certain words into symbols

### DIFF
--- a/src/components/forecast.vue
+++ b/src/components/forecast.vue
@@ -6,7 +6,9 @@
         <conditions :show-pressure="false" />
         <div id="next_forecast" class="full-width reloadable reloadable-8">
           <span class="label"
-            >Forecast for {{ prettifyForecastDay(forecast[0]?.day) }}..<span>{{ forecast[0]?.textSummary }}</span></span
+            >Forecast for {{ prettifyForecastDay(forecast[0]?.day) }}..<span>{{
+              truncateForecastText(forecast[0]?.textSummary)
+            }}</span></span
           >
         </div>
       </template>
@@ -16,13 +18,15 @@
           <br />
           <div class="page_forecast">
             <span class="label"
-              >{{ forecast[page]?.day }}..<span>{{ forecast[page]?.textSummary }}</span></span
+              >{{ forecast[page]?.day }}..<span>{{ truncateForecastText(forecast[page]?.textSummary) }}</span></span
             >
           </div>
           <br />
           <div class="page_forecast">
             <span v-if="page + 1 <= forecast.length - 1" class="label"
-              >{{ forecast[page + 1]?.day }}..<span>{{ forecast[page + 1]?.textSummary }}</span></span
+              >{{ forecast[page + 1]?.day }}..<span>{{
+                truncateForecastText(forecast[page + 1]?.textSummary)
+              }}</span></span
             >
           </div>
         </div>
@@ -34,9 +38,10 @@
 <script>
 const PAGE_CHANGE_FREQUENCY = 15 * 1000;
 
-import conditions from "./conditions.vue";
-import { EventBus } from "../js/EventBus";
 import { mapGetters } from "vuex";
+import { EventBus } from "../js/EventBus";
+import forecastmixin from "../mixins/forecast.mixin";
+import conditions from "./conditions.vue";
 
 export default {
   name: "Forecast",
@@ -46,6 +51,8 @@ export default {
   },
 
   components: { conditions },
+
+  mixins: [forecastmixin],
 
   data() {
     return { page: 0, pageChangeInterval: null };

--- a/src/components/outlook.vue
+++ b/src/components/outlook.vue
@@ -27,10 +27,11 @@ import { format } from "date-fns";
 
 import observedmixin from "../mixins/observed.mixin";
 import stringpadmixin from "../mixins/stringpad.mixin";
+import forecastmixin from "../mixins/forecast.mixin";
 
 export default {
   name: "outlook-screen",
-  mixins: [stringpadmixin, observedmixin],
+  mixins: [stringpadmixin, observedmixin, forecastmixin],
   props: {
     forecast: Array,
     normals: Object,
@@ -61,12 +62,12 @@ export default {
 
     normalLowString() {
       const [normalLow] = this.normals?.textSummary?.split(".");
-      return `Normal ${normalLow}.`;
+      return this.truncateForecastText(`Normal ${normalLow}.`);
     },
 
     normalHighString() {
       const [, normalHigh] = this.normals?.textSummary?.split(".");
-      return `Normal${normalHigh}.`;
+      return this.truncateForecastText(`Normal${normalHigh}.`);
     },
   },
 
@@ -93,8 +94,8 @@ export default {
         const forecastDay = this.forecast[dayIx++];
         const forecastNight = this.forecast[dayIx++];
         const day = forecastDay.day;
-        const high = forecastDay?.temperatures?.textSummary || "";
-        const low = forecastNight?.temperatures?.textSummary || "";
+        const high = this.truncateForecastText(forecastDay?.temperatures?.textSummary || "");
+        const low = this.truncateForecastText(forecastNight?.temperatures?.textSummary || "");
         const condition = forecastDay?.abbreviatedForecast?.textSummary || "";
 
         outlookForEachDay.push({ day, high, low, condition });

--- a/src/mixins/condition.mixin.js
+++ b/src/mixins/condition.mixin.js
@@ -23,6 +23,9 @@ export default {
       // handle light/heavy rainshower
       condition = condition.replace(/\srainshower/gi, " rainshwr");
 
+      // handle light/heacy snowshower
+      condition = condition.replace(/\ssnowshower/gi, " snowshwr");
+
       // final truncation for and/width
       condition = this.truncateConditions(condition);
 

--- a/src/mixins/condition.mixin.js
+++ b/src/mixins/condition.mixin.js
@@ -20,11 +20,8 @@ export default {
       // handle light/heavy conditions
       if (condition.length > 13) condition = condition.replace(/light/gi, "lght").replace(/heavy/gi, "hvy");
 
-      // handle light/heavy rainshower
-      condition = condition.replace(/\srainshower/gi, " rainshwr");
-
-      // handle light/heacy snowshower
-      condition = condition.replace(/\ssnowshower/gi, " snowshwr");
+      // handle light/heavy rain/snow shower
+      condition = condition.replace(/\s(rain|snow)shower/gi, " $1shwr");
 
       // final truncation for and/width
       condition = this.truncateConditions(condition);

--- a/src/mixins/forecast.mixin.js
+++ b/src/mixins/forecast.mixin.js
@@ -1,0 +1,27 @@
+export default {
+  name: "forecast.mixin",
+  methods: {
+    truncateForecastText(text) {
+      if (!text) return "";
+
+      // this will abbreviate certain words/phrases in the forecast to behave more like the original
+      // first step is easy to make KM/H say KMH
+      text = text.replace(/KM\/H/gi, "kmh");
+
+      // turn ZERO into just the number 0
+      text = text.replace(/zero/gi, 0);
+
+      // now we want to find PLUS number and change that into just number
+      text = text.replace(/plus (\d)/gi, "$1");
+
+      // now we want to find MINUS number and change that into just -number
+      text = text.replace(/minus (\d)/gi, "-$1");
+
+      // now we want to find number PERCENT and change that into just number%
+      text = text.replace(/(\d+) percent/gi, "$1%");
+
+      // thats everything for now
+      return text;
+    },
+  },
+};

--- a/src/mixins/forecast.mixin.js
+++ b/src/mixins/forecast.mixin.js
@@ -12,10 +12,10 @@ export default {
       text = text.replace(/zero/gi, 0);
 
       // now we want to find PLUS number and change that into just number
-      text = text.replace(/plus (\d)/gi, "$1");
+      text = text.replace(/plus (\d+)/gi, "$1");
 
       // now we want to find MINUS number and change that into just -number
-      text = text.replace(/minus (\d)/gi, "-$1");
+      text = text.replace(/minus (\d+)/gi, "-$1");
 
       // now we want to find number PERCENT and change that into just number%
       text = text.replace(/(\d+) percent/gi, "$1%");

--- a/tests/forecast.spec.js
+++ b/tests/forecast.spec.js
@@ -92,8 +92,11 @@ test("prettifyForecastDay: returns 'tonight' correctly", (done) => {
 test("truncateForecastText: truncates forecasts properly", (done) => {
   expect(vm.truncateForecastText("")).toStrictEqual("");
   expect(vm.truncateForecastText("high plus 4")).toStrictEqual("high 4");
+  expect(vm.truncateForecastText("high plus 12")).toStrictEqual("high 12");
   expect(vm.truncateForecastText("high zero")).toStrictEqual("high 0");
   expect(vm.truncateForecastText("low minus 6")).toStrictEqual("low -6");
+  expect(vm.truncateForecastText("low minus 16")).toStrictEqual("low -16");
+  expect(vm.truncateForecastText("low minus 24")).toStrictEqual("low -24");
   expect(vm.truncateForecastText("low zero")).toStrictEqual("low 0");
   expect(vm.truncateForecastText("wind northeast 20km/h")).toStrictEqual("wind northeast 20kmh");
   expect(vm.truncateForecastText("40 percent chance of showers")).toStrictEqual("40% chance of showers");

--- a/tests/forecast.spec.js
+++ b/tests/forecast.spec.js
@@ -44,6 +44,19 @@ test("generateForecastPages: sets the page to 0 and changes page after 15s", (do
   done();
 });
 
+test("generateForecastPages: sets the page to 0 and changes page after 50s if it was a reload", (done) => {
+  jest.useFakeTimers();
+  const spy = jest.spyOn(vm, "changePage");
+
+  vm.generateForecastPages(true);
+  expect(vm.page).toBe(0);
+  jest.advanceTimersByTime(50 * 1000);
+  expect(spy).toHaveBeenCalled();
+  expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 50 * 1000);
+
+  done();
+});
+
 test("changePage: moves the 'page' forward by 2 if we're not on the first page", (done) => {
   wrapper.setProps({ forecast: ecForecast });
   vm.$nextTick(() => {
@@ -92,5 +105,6 @@ test("truncateForecastText: truncates forecasts properly", (done) => {
 test("destroyed: removes page change interval", (done) => {
   wrapper.unmount();
   expect(clearInterval).toHaveBeenCalled();
+  expect(clearTimeout).toHaveBeenCalled();
   done();
 });

--- a/tests/forecast.spec.js
+++ b/tests/forecast.spec.js
@@ -76,6 +76,19 @@ test("prettifyForecastDay: returns 'tonight' correctly", (done) => {
   done();
 });
 
+test("truncateForecastText: truncates forecasts properly", (done) => {
+  expect(vm.truncateForecastText("")).toStrictEqual("");
+  expect(vm.truncateForecastText("high plus 4")).toStrictEqual("high 4");
+  expect(vm.truncateForecastText("high zero")).toStrictEqual("high 0");
+  expect(vm.truncateForecastText("low minus 6")).toStrictEqual("low -6");
+  expect(vm.truncateForecastText("low zero")).toStrictEqual("low 0");
+  expect(vm.truncateForecastText("wind northeast 20km/h")).toStrictEqual("wind northeast 20kmh");
+  expect(vm.truncateForecastText("40 percent chance of showers")).toStrictEqual("40% chance of showers");
+  expect(vm.truncateForecastText("100 percent chance of flurries")).toStrictEqual("100% chance of flurries");
+  expect(vm.truncateForecastText("5 percent chance of flurries")).toStrictEqual("5% chance of flurries");
+  done();
+});
+
 test("destroyed: removes page change interval", (done) => {
   wrapper.unmount();
   expect(clearInterval).toHaveBeenCalled();

--- a/tests/surrounding.spec.js
+++ b/tests/surrounding.spec.js
@@ -152,6 +152,10 @@ test("trimCondition: handles light/heavy and rainshower better", (done) => {
   expect(vm.trimCondition("mostly clear")).toBe("mostly clear");
   expect(vm.trimCondition("light rain")).toBe("light rain");
   expect(vm.trimCondition("rainshower")).toBe("rainshower");
+  expect(vm.trimCondition("light rainshower")).toBe("lght rainshwr");
+  expect(vm.trimCondition("heavy rainshower")).toBe("hvy rainshwr");
+  expect(vm.trimCondition("light snowshower")).toBe("lght snowshwr");
+  expect(vm.trimCondition("heavy snowshower")).toBe("hvy snowshwr");
 
   done();
 });


### PR DESCRIPTION
# Changes
- Handle Light/Heavy Snowshower on "City Temp/Conditions" screen
- Update the forecast text so that certain words are turned into symbols (minus temp, percent chance, etc.)
- Pause for 50s on the initial forecast screen after doing a reload