### PR TITLE
update: forecast/warning tidy up

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,7 +45,7 @@ const SCREENS = {
   FORECAST: { id: 2, length: 160 },
   SURROUNDING: { id: 3, length: 80 },
   ALMANAC: { id: 4, length: 20 },
-  WARNINGS: { id: 5, length: 65 * 10 }, // enough for 10 warnings if things get crazy
+  WARNINGS: { id: 5, length: 30 * 10 }, // enough for 10 warnings if things get crazy
   WINDCHILL: { id: 6, length: 20 },
   MB_HIGH_LOW: { id: 7, length: 20 },
   CITY_STATS: { id: 8, length: 20 },
@@ -58,9 +58,9 @@ const SCREENS = {
 };
 const SCREEN_ROTATION = [
   // SCREENS.CURRENT_CONDITIONS,
+  SCREENS.WARNINGS,
   SCREENS.FORECAST,
   SCREENS.OUTLOOK,
-  SCREENS.WARNINGS,
   SCREENS.ALMANAC,
   SCREENS.AQHI_WARNING,
   SCREENS.MB_HIGH_LOW,
@@ -115,7 +115,7 @@ export default {
     return {
       screenChanger: null,
       now: new Date(),
-      rotationIndex: 0,
+      rotationIndex: 1,
       currentScreen: SCREENS.FORECAST,
       province: {
         highLowAroundMB: {},

--- a/src/components/forecast.vue
+++ b/src/components/forecast.vue
@@ -15,7 +15,7 @@
       <template v-else>
         <div id="forecast_cont">
           <div id="title">{{ ecCity }} Forecast Cont..</div>
-          <br />
+          <br v-if="!removeLineBreaks" />
           <div class="page_forecast">
             <span class="label"
               >{{ forecast[page]?.day }}..<span>{{
@@ -23,7 +23,7 @@
               }}</span></span
             >
           </div>
-          <br />
+          <br v-if="!removeLineBreaks" />
           <div class="page_forecast">
             <span v-if="page + 1 <= forecast.length - 1" class="label"
               >{{ forecast[page + 1]?.day }}..<span>{{
@@ -66,6 +66,12 @@ export default {
 
     forecastUnavailable() {
       return !this.forecast || !this.forecast.length;
+    },
+
+    removeLineBreaks() {
+      const forecastLength =
+        this.forecast[this.page]?.textSummary?.length + this.forecast[this.page + 1]?.textSummary?.length;
+      return this.page !== 0 && forecastLength >= 240;
     },
   },
 

--- a/src/components/forecast.vue
+++ b/src/components/forecast.vue
@@ -106,10 +106,9 @@ export default {
     },
 
     changePage() {
-      if (!this.page) this.page = ++this.page % this.forecast?.length;
-      else this.page = (this.page + 2) % this.forecast?.length;
+      this.page = ++this.page % (this.forecast?.length - 1);
 
-      if (!this.page || this.forecastUnavailable) return EventBus.emit("forecast-complete");
+      if (!this.page || this.forecastUnavailable) EventBus.emit("forecast-complete");
     },
 
     prettifyForecastDay(val) {

--- a/src/components/outlook.vue
+++ b/src/components/outlook.vue
@@ -80,12 +80,12 @@ export default {
       if (!this.forecast) return;
 
       // figure out what 3 days from now is
-      const threeDaysAway = this.getDaysAheadFromObserved(this.ecObservedAtStation, 3);
-      const threeDaysAwayName = format(threeDaysAway, "EEEE");
+      const twoDaysAway = this.getDaysAheadFromObserved(this.ecObservedAtStation, 2);
+      const twoDaysAwayName = format(twoDaysAway, "EEEE");
 
       // we need to get day 3, 4, and 5 from the forecast. however we know that the forecast includes "night" forecasts too
       // first thing is to find the index in the forecast that is for threeDaysAway
-      const startIx = this.forecast.findIndex((f) => f.day === threeDaysAwayName.toLocaleLowerCase());
+      const startIx = this.forecast.findIndex((f) => f.day === twoDaysAwayName.toLocaleLowerCase());
       if (startIx === -1) return;
 
       // now we can build up a forecast for each day

--- a/src/components/warnings.vue
+++ b/src/components/warnings.vue
@@ -84,9 +84,10 @@ export default {
     },
 
     truncateWarningDescription(description) {
-      let [shortDescription] = description.split(".");
+      const paragraphSplit = description.split(/.\s\s/);
 
       // get rid of some weird ### description stuff
+      let shortDescription = paragraphSplit.slice(0, 2).join(". ");
       shortDescription = (shortDescription || "").split(/\n\n###/g)[0];
 
       // remove impacted locations as its a giant list

--- a/src/components/warnings.vue
+++ b/src/components/warnings.vue
@@ -84,12 +84,14 @@ export default {
     },
 
     truncateWarningDescription(description) {
+      let [shortDescription] = description.split(".");
+
       // get rid of some weird ### description stuff
-      description = (description || "").split(/\n\n###/g)[0];
+      shortDescription = (shortDescription || "").split(/\n\n###/g)[0];
 
       // remove impacted locations as its a giant list
-      description = description.split("Locations impacted")[0];
-      return description.trim();
+      shortDescription = shortDescription.split("Locations impacted")[0];
+      return shortDescription.trim();
     },
   },
 };

--- a/src/vuex/getters-ecdata.js
+++ b/src/vuex/getters-ecdata.js
@@ -30,7 +30,7 @@ export default {
 
   ecShortForecast: (state) => {
     const { forecast } = state.ecData || [];
-    return forecast && forecast.slice(0, 5);
+    return forecast && forecast.slice(0, 3);
   },
 
   ecRegionalNormals: (state) => {

--- a/tests/forecast.spec.js
+++ b/tests/forecast.spec.js
@@ -57,12 +57,12 @@ test("generateForecastPages: sets the page to 0 and changes page after 50s if it
   done();
 });
 
-test("changePage: moves the 'page' forward by 2 if we're not on the first page", (done) => {
+test("changePage: moves the 'page' forward by 1 if we're not on the first page", (done) => {
   wrapper.setProps({ forecast: ecForecast });
   vm.$nextTick(() => {
     vm.page = 1;
     vm.changePage();
-    expect(vm.page).toBe(3);
+    expect(vm.page).toBe(2);
     done();
   });
 });
@@ -74,9 +74,9 @@ test("changePage: switches away from the forecast screen on the last page", (don
     done();
   });
 
-  wrapper.setProps({ forecast: ecForecast });
+  wrapper.setProps({ forecast: ecForecast.slice(0, 3) });
   vm.$nextTick(() => {
-    vm.page = 3;
+    vm.page = 0;
     vm.changePage();
     vm.changePage();
   });

--- a/tests/info-screen.spec.js
+++ b/tests/info-screen.spec.js
@@ -37,7 +37,7 @@ describe("info-screens.js", () => {
 
   test("createInfoScreen: makes sure end or isInfinite is set", (done) => {
     expect(configInfoScreens.createInfoScreen("test", formattedToday)).toBeFalsy();
-    expect(configInfoScreens.createInfoScreen("test", formattedToday, "2022-12-14")).toBeTruthy();
+    expect(configInfoScreens.createInfoScreen("test", formattedToday, formattedTomorrow)).toBeTruthy();
     expect(configInfoScreens.createInfoScreen("test", formattedToday, null, true)).toBeTruthy();
     done();
   });

--- a/tests/warnings.spec.js
+++ b/tests/warnings.spec.js
@@ -57,6 +57,15 @@ const fakeEndedUrgentWarning = {
   urgency: "Past",
 };
 
+const reallyLongWarningDescription = {
+  identifier: "e",
+  references: "",
+  expires: "2022-12-15T00:00:00",
+  headline: "special weather statement",
+  description:
+    "Prolonged snow event over southeastern Saskatchewan and southern Manitoba beginning late Tuesday evening with some local areas receiving upwards of 20-30 cm by the weekend. The Colorado low has already begun to spread snow over southwestern Manitoba as of late Tuesday afternoon.  The area of snow will expand in coverage on Tuesday night with most areas seeing some accumulation by Wednesday morning.  With the above seasonable temperatures in place as the low pressure system approaches, the snow is expected to be a heavier wet snow. The worst conditions are expected to be in the communities along the international border.",
+};
+
 test("warningsUnavailable: computes correctly", (done) => {
   expect(vm.warningsUnavailable).toBe(true);
   done();
@@ -156,6 +165,13 @@ test("truncateWarningDescription: removes redundant info", (done) => {
   expect(vm.truncateWarningDescription(fakeWarning.description)).toBe(fakeWarning.description);
   expect(vm.truncateWarningDescription(fakeEndedUrgentWarning.description)).toBe(fakeEndedUrgentWarning.description);
   expect(vm.truncateWarningDescription(fakeUrgentWarning.description)).toBe("stuff will happen");
+  done();
+});
+
+test("truncateWarningDescription: splits correctly at the right point", async (done) => {
+  expect(vm.truncateWarningDescription(reallyLongWarningDescription.description)).toStrictEqual(
+    "Prolonged snow event over southeastern Saskatchewan and southern Manitoba beginning late Tuesday evening with some local areas receiving upwards of 20-30 cm by the weekend"
+  );
   done();
 });
 

--- a/tests/warnings.spec.js
+++ b/tests/warnings.spec.js
@@ -43,7 +43,7 @@ const fakeUrgentWarning = {
   references: "a,b,c",
   expires: "2022-06-15T00:00:00",
   headline: "severe weather warning in effect",
-  description: "stuff will happen Locations impacted: some location here ### when warning appears, run",
+  description: "stuff will happen Locations impacted: some location here\n\n### when warning appears, run",
   severity: "medium",
   urgency: "Immediate",
 };
@@ -63,7 +63,16 @@ const reallyLongWarningDescription = {
   expires: "2022-12-15T00:00:00",
   headline: "special weather statement",
   description:
-    "Prolonged snow event over southeastern Saskatchewan and southern Manitoba beginning late Tuesday evening with some local areas receiving upwards of 20-30 cm by the weekend. The Colorado low has already begun to spread snow over southwestern Manitoba as of late Tuesday afternoon.  The area of snow will expand in coverage on Tuesday night with most areas seeing some accumulation by Wednesday morning.  With the above seasonable temperatures in place as the low pressure system approaches, the snow is expected to be a heavier wet snow. The worst conditions are expected to be in the communities along the international border.",
+    "Prolonged snow event over southeastern Saskatchewan and southern Manitoba beginning late Tuesday evening with some local areas receiving upwards of 20-30 cm by the weekend.  The Colorado low has already begun to spread snow over southwestern Manitoba as of late Tuesday afternoon.  The area of snow will expand in coverage on Tuesday night with most areas seeing some accumulation by Wednesday morning.  With the above seasonable temperatures in place as the low pressure system approaches, the snow is expected to be a heavier wet snow. The worst conditions are expected to be in the communities along the international border.  As the area of low pressure moves through the Midwestern states towards the Great Lakes on Wednesday night and into Thursday, a hang back area of snowfall is expected to linger over southeastern Saskatchewan and southern Manitoba through the week. At this time, it appears that for each forecast period, snowfall amounts are expected to stay sub-warning. However, with the snow beginning overnight on Tuesday and continuing through the week, the accumulation of snow over such a prolonged time will have continuous impact over the region. The accumulations will range from 10-20 cm, with some local amounts reaching as high as 30 cm by the weekend.",
+};
+
+const anotherReallyLongWarningDescription = {
+  identifier: "e",
+  references: "",
+  expires: "2022-12-15T00:00:00",
+  headline: "special weather statement",
+  description:
+    "As of Wednesday afternoon, the first two rounds of snow have given widespread snowfall amounts of 10 to 15 cm across southern Manitoba, with localized higher amounts.  Only light snow is expected over southeastern Manitoba on Wednesday night ahead of another band of heavier snow expected on Thursday.  Additionally, some freezing drizzle may be mixed in at times.  Over western Manitoba and eastern Saskatchewan, snowfall amounts will be in the 5 to 10 cm range tonight.",
 };
 
 test("warningsUnavailable: computes correctly", (done) => {
@@ -170,7 +179,10 @@ test("truncateWarningDescription: removes redundant info", (done) => {
 
 test("truncateWarningDescription: splits correctly at the right point", async (done) => {
   expect(vm.truncateWarningDescription(reallyLongWarningDescription.description)).toStrictEqual(
-    "Prolonged snow event over southeastern Saskatchewan and southern Manitoba beginning late Tuesday evening with some local areas receiving upwards of 20-30 cm by the weekend"
+    "Prolonged snow event over southeastern Saskatchewan and southern Manitoba beginning late Tuesday evening with some local areas receiving upwards of 20-30 cm by the weekend. The Colorado low has already begun to spread snow over southwestern Manitoba as of late Tuesday afternoon"
+  );
+  expect(vm.truncateWarningDescription(anotherReallyLongWarningDescription.description)).toStrictEqual(
+    "As of Wednesday afternoon, the first two rounds of snow have given widespread snowfall amounts of 10 to 15 cm across southern Manitoba, with localized higher amounts. Only light snow is expected over southeastern Manitoba on Wednesday night ahead of another band of heavier snow expected on Thursday"
   );
   done();
 });


### PR DESCRIPTION
Moves the warnings to the first screen in the rotation (still reloads to forecast when new data comes in). Makes sure that the warning message is only as long as the screen allows.

Forecast has ditched the auto-generated portions (generally two-three days out) and moved those to the outlook screen. The forecast screen will also removing line spacing if the forecast is extra lengthy.