### PR TITLE
feat: paginate canadian cities by area, not number

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@
           <aqhiwarning v-if="isAQHIWarning" :aqhi="ecAirQuality" />
           <outlook v-if="isOutlook" :forecast="ecForecast" :normals="ecRegionalNormals" />
           <mbhighlow v-if="isMBHighLow" :enabled="showMBHighLowSetting" :manitoba-data="province.highLowAroundMB" />
-          <surrounding v-if="isSurrounding" :observations="surrounding.canada" />
+          <surrounding v-if="isSurrounding" :group-by-area="true" :observations="surrounding.canada" />
           <surrounding v-if="isUSSurrounding" :observations="surrounding.usa" />
           <almanac v-if="isAlmanac" :almanac="ecAlmanac" />
           <warnings v-if="isWarnings" :warnings="ecWarnings" />


### PR DESCRIPTION
This will make sure that the Canadian cities on the city/temp/condition screen will paginate by area rather than in blocks of 7. This solves the issue of observations mixing regions #377 .

This also solves #372 . Any pages with just one station on are skipped over.