### PR TITLE
fix(date): not handling nst timezone properly

### DIFF
--- a/src/__tests__/ecccDate.test.ts
+++ b/src/__tests__/ecccDate.test.ts
@@ -21,10 +21,12 @@ describe("Helpers for ECCC dates", () => {
     expect(ecccDateStringToTSDate(ecccDateString)).toStrictEqual(expectedDate);
   });
 
-  it("parses to a newfoundland date object correctly", () => {
+  it("parses to custom timezone (ADT/AST/NDT/NST) objects correctly", () => {
     const ecccDateString = "Sunday August 13, 2023 at 12:00";
-    expect(ecccDateStringToTSDate(`${ecccDateString} AST`)).toStrictEqual(new Date(2023, 7, 13, 11, 0, 0));
+    expect(ecccDateStringToTSDate(`${ecccDateString} ADT`)).toStrictEqual(new Date(2023, 7, 13, 11, 0, 0));
+    expect(ecccDateStringToTSDate(`${ecccDateString} AST`)).toStrictEqual(new Date(2023, 7, 13, 12, 0, 0));
     expect(ecccDateStringToTSDate(`${ecccDateString} NDT`)).toStrictEqual(new Date(2023, 7, 13, 10, 30, 0));
+    expect(ecccDateStringToTSDate(`${ecccDateString} NST`)).toStrictEqual(new Date(2023, 7, 13, 11, 30, 0));
   });
 
   it("gets the correct months for the current season", () => {

--- a/src/lib/date/ecccDate.ts
+++ b/src/lib/date/ecccDate.ts
@@ -2,8 +2,13 @@ import { format } from "date-fns";
 import { getIsWinterSeason } from "./season";
 
 export function ecccDateStringToTSDate(date: string) {
-  // JS doesn't see ATS/NDT (newfoundland time) as a valid date for some reason
-  const fixedTimezone = date.replace("AST", "GMT-0300").replace("NDT", "GMT-0230").replace("NST", "GMT-0330");
+  // JS doesn't see atlantic and newfoundland standard/daylight time as a valid time for some reason
+  const fixedTimezone = date
+    .replace("ADT", "GMT-0300")
+    .replace("AST", "GMT-0400")
+    .replace("NDT", "GMT-0230")
+    .replace("NST", "GMT-0330");
+
   return new Date(fixedTimezone.replace(" at", "").replace(",", ""));
 }
 

--- a/src/lib/date/ecccDate.ts
+++ b/src/lib/date/ecccDate.ts
@@ -3,7 +3,7 @@ import { getIsWinterSeason } from "./season";
 
 export function ecccDateStringToTSDate(date: string) {
   // JS doesn't see ATS/NDT (newfoundland time) as a valid date for some reason
-  const fixedTimezone = date.replace("AST", "GMT-0300").replace("NDT", "GMT-0230");
+  const fixedTimezone = date.replace("AST", "GMT-0300").replace("NDT", "GMT-0230").replace("NST", "GMT-0330");
   return new Date(fixedTimezone.replace(" at", "").replace(",", ""));
 }
 


### PR DESCRIPTION
Handle the Atlantic and Newfoundland timezones manually since JS doesn't seem them as valid for some reason. Will close #875.