### PR TITLE
fix(national): not updating after startup

### DIFF
--- a/src/lib/eccc/conditions.ts
+++ b/src/lib/eccc/conditions.ts
@@ -177,7 +177,7 @@ class CurrentConditions {
           this.getTempRecordsForDay();
 
           // tell national stations what we're expecting
-          eventbus.emit(EVENT_BUS_MAIN_STATION_UPDATE_NEW_CONDITIONS, conditionUUID);
+          eventbus.emit(EVENT_BUS_MAIN_STATION_UPDATE_NEW_CONDITIONS, weather.current?.dateTime[0].timeStamp);
 
           logger.log("Parsed new conditions with UUID of", conditionUUID);
         })

--- a/src/lib/national/national.ts
+++ b/src/lib/national/national.ts
@@ -43,7 +43,10 @@ class NationalWeather {
     // update expected condition uuid from main station
     const hadExpectedConditionUUID = !!this._expectedConditionUUID;
     const shouldClear = this._expectedConditionUUID !== conditionUUID;
-    this._expectedConditionUUID = conditionUUID;
+
+    // this._expectedConditionUUID = conditionUUID;
+    // with the June 2025 update they seem to have changed the raw timestamp data
+    this._expectedConditionUUID = conditionUUID.slice(0, -4);
 
     // if we didn't have an expected condition uuid, we dont need to force an update
     if (!hadExpectedConditionUUID) return;


### PR DESCRIPTION
- Fixes an issue where the national weather data wasn't updating after the first fetch