### PR TITLE
fix(eccc): MSC citypage HTTP (datamart + mirrors + stale fallback)

### DIFF
--- a/src/__tests__/ecccConditions.test.ts
+++ b/src/__tests__/ecccConditions.test.ts
@@ -48,8 +48,9 @@ describe("CurrentConditions", () => {
       const mostRecentRequest = moxios.requests.mostRecent();
       mostRecentRequest.respondWith({ status: 200, response: ecccConditions }).then(() => {
         const observed = conditions.observed();
-        expect(observed).toEqual({
+        expect(observed).toMatchObject({
           ...expectedObserved,
+          fetchedAt: expect.any(String),
           almanac: {
             ...expectedObserved.almanac,
             temperatures: { ...expectedObserved.almanac.temperatures, lastYearMin: null, lastYearMax: null },

--- a/src/consts/http.consts.ts
+++ b/src/consts/http.consts.ts
@@ -1,0 +1,4 @@
+/** Outbound HTTP from Node (ECCC, datamart, CAP, etc.). */
+export const BACKEND_HTTP_TIMEOUT_MS = 45_000;
+
+export const HTTP_MAX_REDIRECTS = 5;

--- a/src/consts/index.ts
+++ b/src/consts/index.ts
@@ -1,4 +1,6 @@
 export * from "./server.consts";
+export * from "./http.consts";
+export * from "./reliability.consts";
 export * from "./storage.consts";
 export * from "./screens.consts";
 export * from "./flavour.consts";

--- a/src/consts/reliability.consts.ts
+++ b/src/consts/reliability.consts.ts
@@ -1,0 +1,52 @@
+/** Max age for last-known-good auxiliary API payloads (national / USA / airport METAR). */
+export function rwcLkgMaxAgeMs(): number {
+  return envPositiveInt("RWC_LKG_MAX_AGE_MS", 90 * 60 * 1000);
+}
+
+/** HTTP GET retries for idempotent upstream calls (total attempts = 1 + this). */
+export function rwcHttpRetryCount(): number {
+  const n = envPositiveInt("RWC_HTTP_RETRY_COUNT", 2);
+  return Math.min(5, Math.max(0, n));
+}
+
+export function rwcHttpRetryBackoffMinMs(): number {
+  return envPositiveInt("RWC_HTTP_RETRY_BACKOFF_MIN_MS", 100);
+}
+
+export function rwcHttpRetryBackoffMaxMs(): number {
+  return envPositiveInt("RWC_HTTP_RETRY_BACKOFF_MAX_MS", 2000);
+}
+
+/**
+ * Extra full GET cycles for the **current** UTC hourly citypage directory only (`/today/citypage_weather/<prov>/<HH>/`).
+ * Mirrors often 404 for a short window right after the hour until the listing exists.
+ */
+export function rwcDatamartHourlyDirExtraRetries(): number {
+  return Math.min(5, Math.max(0, envPositiveInt("RWC_DATAMART_HOURLY_DIR_EXTRA_RETRIES", 2)));
+}
+
+/** Pause between those publication-lag retries (ms); small jitter is added in the caller. */
+export function rwcDatamartHourlyDirRetryDelayMs(): number {
+  return envPositiveInt("RWC_DATAMART_HOURLY_DIR_RETRY_DELAY_MS", 12_000);
+}
+
+/** Consecutive failures before upstream host enters cool-off. */
+export function rwcCircuitFailureThreshold(): number {
+  return Math.min(20, Math.max(2, envPositiveInt("RWC_CIRCUIT_FAILURE_THRESHOLD", 5)));
+}
+
+export function rwcCircuitCoolOffMs(): number {
+  return envPositiveInt("RWC_CIRCUIT_COOL_OFF_MS", 120_000);
+}
+
+/** Warn once at startup if free disk space is below this many MiB (0 = disabled). */
+export function rwcMinDiskFreeMib(): number {
+  return Math.max(0, envPositiveInt("RWC_MIN_DISK_FREE_MIB", 0));
+}
+
+function envPositiveInt(key: string, defaultVal: number): number {
+  const raw = process.env[key]?.trim();
+  if (!raw?.length) return defaultVal;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : defaultVal;
+}

--- a/src/lib/backendAxios.ts
+++ b/src/lib/backendAxios.ts
@@ -1,2 +1,7 @@
 import axios from "axios";
-export default axios.create();
+import { BACKEND_HTTP_TIMEOUT_MS, HTTP_MAX_REDIRECTS } from "consts";
+
+export default axios.create({
+  timeout: BACKEND_HTTP_TIMEOUT_MS,
+  maxRedirects: HTTP_MAX_REDIRECTS,
+});

--- a/src/lib/eccc/citypageStaleFallback.ts
+++ b/src/lib/eccc/citypageStaleFallback.ts
@@ -1,0 +1,50 @@
+import { parseISO } from "date-fns";
+
+/** If no successful citypage parse in this window, run a datamart-backed HTTP fetch (AMQP may be quiet). */
+export const DEFAULT_CITYPAGE_STALE_FALLBACK_AFTER_MS = 2 * 60 * 60 * 1000;
+
+/** How often to evaluate staleness (not how often to HTTP hit — coalesced via `requestConditionsFetch`). */
+export const DEFAULT_CITYPAGE_STALE_FALLBACK_CHECK_INTERVAL_MS = 15 * 60 * 1000;
+
+function parsePositiveIntEnv(name: string, fallback: number, min: number, max?: number): number {
+  const raw = process.env[name];
+  if (!raw || !/^\d+$/.test(raw.trim())) return fallback;
+  let n = parseInt(raw.trim(), 10);
+  if (!Number.isFinite(n)) return fallback;
+  if (n < min) n = min;
+  if (max != null && n > max) n = max;
+  return n;
+}
+
+/** Set to `1` to disable the periodic stale check (AMQP + bootstrap HTTP only). */
+export function isCitypageStaleFallbackDisabled(): boolean {
+  return process.env.RWC_CITYPAGE_STALE_FALLBACK_DISABLED === "1";
+}
+
+export function citypageStaleFallbackAfterMs(): number {
+  return parsePositiveIntEnv(
+    "RWC_CITYPAGE_STALE_FALLBACK_AFTER_MS",
+    DEFAULT_CITYPAGE_STALE_FALLBACK_AFTER_MS,
+    5 * 60 * 1000
+  );
+}
+
+export function citypageStaleFallbackCheckIntervalMs(): number {
+  return parsePositiveIntEnv(
+    "RWC_CITYPAGE_STALE_FALLBACK_CHECK_MS",
+    DEFAULT_CITYPAGE_STALE_FALLBACK_CHECK_INTERVAL_MS,
+    60 * 1000,
+    24 * 60 * 60 * 1000
+  );
+}
+
+export function shouldRunCitypageStaleHttpPoll(
+  lastSuccessfulFetchIso: string | null,
+  nowMs: number,
+  staleAfterMs: number
+): boolean {
+  if (lastSuccessfulFetchIso == null || lastSuccessfulFetchIso === "") return true;
+  const t = parseISO(lastSuccessfulFetchIso).getTime();
+  if (!Number.isFinite(t)) return true;
+  return nowMs - t >= staleAfterMs;
+}

--- a/src/lib/eccc/conditions.ts
+++ b/src/lib/eccc/conditions.ts
@@ -1,5 +1,6 @@
 const Weather = require("ec-weather-js");
-import axios from "lib/backendAxios";
+import { isAxiosError, type AxiosResponse } from "axios";
+import backendAxios from "lib/backendAxios";
 import { listen } from "lib/amqp";
 import { initializeConfig } from "lib/config";
 import Logger from "lib/logger";
@@ -41,20 +42,28 @@ import { initializeClimateNormals } from "./climateNormals";
 import { generateConditionsUUID } from "./utils";
 import eventbus from "lib/eventbus";
 import { getTempRecordForDate } from "lib/temprecords";
-import { GetWeatherFileFromECCC } from "./datamart";
+import { GetWeatherFileFromECCC, legacyHpfxCitypageEnglishXmlUrl } from "./datamart";
 import { isLooseNull } from "lib/isnull";
-
-const ECCC_BASE_API_URL = "https://dd.weather.gc.ca/citypage_weather/xml/";
-const ECCC_API_ENGLISH_SUFFIX = "_e.xml";
+import { axiosGetWithMscMirror, normalizeMscHttpUrl } from "lib/eccc/mscHttpMirror";
+import {
+  citypageStaleFallbackAfterMs,
+  citypageStaleFallbackCheckIntervalMs,
+  isCitypageStaleFallbackDisabled,
+  shouldRunCitypageStaleHttpPoll,
+} from "lib/eccc/citypageStaleFallback";
 
 const logger = new Logger("conditions");
 const config = initializeConfig();
 const historicalData = initializeHistoricalTempPrecip();
 const climateNormals = initializeClimateNormals();
 
+/** `forecastGroup.regionalNormals` after ec-weather-js restructure (on `weather.all`). */
+type RegionalNormalsFromFeed = {
+  temperature?: ECCCAlmanacTemp | ECCCAlmanacTemp[];
+};
+
 class CurrentConditions {
   private _amqpConnection: Connection;
-  private _apiUrl: string;
   private _conditionUUID: string;
   private _weatherStationTimeData: WeatherStationTimeData;
   private _weatherStationCityName: string;
@@ -74,6 +83,12 @@ class CurrentConditions {
   private _windchill: number | null;
   private _forecast: WeekForecast;
   public stationLatLong: LatLong = { lat: 0, long: 0 };
+  private _conditionsFetchBusy = false;
+  private _conditionsFetchPending: { url?: string } | null = null;
+  private _conditionsFetchedAt: string | null = null;
+  private _conditionsApplyGen = 0;
+  private _conditionsInFlightAbort: AbortController | null = null;
+  private _staleHttpFallbackTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor() {
     this.initialize();
@@ -84,116 +99,219 @@ class CurrentConditions {
     this._weatherStationID = config?.primaryLocation?.location;
     this._conditionUUID = "";
 
+    this.clearStaleHttpFallbackWatcher();
     this.startAMQPConnection();
-    this._apiUrl = `${ECCC_BASE_API_URL}${config.primaryLocation.province}/${this._weatherStationID}${ECCC_API_ENGLISH_SUFFIX}`;
-    this.fetchConditions();
+    this.requestConditionsFetch();
+    this.startStaleHttpFallbackWatcher();
+  }
+
+  private clearStaleHttpFallbackWatcher(): void {
+    if (this._staleHttpFallbackTimer !== null) {
+      clearInterval(this._staleHttpFallbackTimer);
+      this._staleHttpFallbackTimer = null;
+    }
+  }
+
+  /**
+   * If MSC AMQP is silent for a long time, still re-fetch citypage XML via the same datamart/HPFX path
+   * as bootstrap so the display can advance when ECCC publishes without us seeing a broker notification.
+   */
+  private startStaleHttpFallbackWatcher(): void {
+    this.clearStaleHttpFallbackWatcher();
+    if (process.env.NODE_ENV === "test" || isCitypageStaleFallbackDisabled()) return;
+
+    const intervalMs = citypageStaleFallbackCheckIntervalMs();
+    const staleAfterMs = citypageStaleFallbackAfterMs();
+    this._staleHttpFallbackTimer = setInterval(() => this.tickStaleHttpFallback(), intervalMs);
+    logger.log(
+      "Citypage stale HTTP fallback: check every",
+      Math.round(intervalMs / 60000),
+      "min if last successful parse older than",
+      Math.round(staleAfterMs / 3600000),
+      "h"
+    );
+  }
+
+  private tickStaleHttpFallback(): void {
+    if (this._conditionsFetchBusy) return;
+    const staleAfterMs = citypageStaleFallbackAfterMs();
+    if (!shouldRunCitypageStaleHttpPoll(this._conditionsFetchedAt, Date.now(), staleAfterMs)) return;
+
+    logger.log(
+      "Citypage stale HTTP fallback: requesting datamart resolve + fetch (last successful parse exceeded threshold)"
+    );
+    this.requestConditionsFetch();
   }
 
   private startAMQPConnection() {
     if (this._amqpConnection) this._amqpConnection.disconnect();
 
-    // hook up the amqp listener
     const { connection, emitter: listener } = listen({
       amqp_subtopic: `*.WXO-DD.citypage_weather.${config.primaryLocation.province}.#`,
     });
 
-    // handle errors and messages
     listener
-      .on("error", (...error) => logger.error("AMQP error:", error))
+      .on("error", (...error) => {
+        logger.error("AMQP error:", error);
+      })
       .on("message", (date: string, url: string) => {
-        // make sure its relevant to us
         if (!url.endsWith(`${this._weatherStationID}_en.xml`)) return;
 
-        this.fetchConditions(url);
+        this.requestConditionsFetch(url);
         logger.log("Received new conditions from AMQP at", date);
       });
 
-    // store the connection so we can disconnect if needed
     this._amqpConnection = connection;
 
     logger.log("Started AMQP conditions listener");
   }
 
-  private async fetchConditions(url?: string) {
-    // if we got a url from amqp then use that, otherwise we need to find the correct one
-    const searchedURL =
-      url != undefined
-        ? url
-        : await GetWeatherFileFromECCC(config.primaryLocation.province, config.primaryLocation.location);
+  /** Coalesces overlapping fetches; AMQP URL wins over a queued datamart resolve. */
+  private requestConditionsFetch(url?: string) {
+    if (this._conditionsFetchBusy) {
+      if (url !== undefined) {
+        this._conditionsFetchPending = { url };
+        this._conditionsInFlightAbort?.abort();
+      } else if (!this._conditionsFetchPending) {
+        this._conditionsFetchPending = {};
+      }
+      return;
+    }
+    void this.runConditionsFetch(url);
+  }
 
-    // now that we know we have a file to use, we can go and get it
-    searchedURL &&
-      axios
-        .get(searchedURL)
-        .then((resp) => {
-          // parse to weather object
-          const weather = new Weather(resp.data);
-          if (!weather) return;
+  public getLastSuccessfulFetchIso(): string | null {
+    return this._conditionsFetchedAt;
+  }
 
-          // make sure all weather is there
-          const { all: allWeather } = weather;
-          if (!allWeather) return;
+  /** Operator hook: coalesced citypage HTTP fetch (same path as AMQP-driven updates). */
+  public requestCitypageRefresh(): void {
+    this.requestConditionsFetch();
+  }
 
-          // store station lat/long
-          this.parseStationLatLong(allWeather.location.name);
+  /**
+   * Parse citypage GET response into live conditions. `unparsed` means try another URL (bad body).
+   */
+  private applyCitypageHttpResponse(resp: AxiosResponse, applyGen: number): "applied" | "stale" | "unparsed" {
+    if (applyGen !== this._conditionsApplyGen) return "stale";
 
-          // generate uuid for these conditions and reject if a config option is on
-          const conditionUUID = generateConditionsUUID(weather.current?.dateTime[1].timeStamp ?? "");
-          if (config.misc.rejectInHourConditionUpdates && conditionUUID === this._conditionUUID) {
-            // update the forecast at least but reject the rest of it
-            logger.log("Rejecting in-hour conditions update as", conditionUUID, "was already parsed");
-            return;
-          }
+    const weather = new Weather(resp.data);
+    if (!weather) return "unparsed";
 
-          // store the condition uuid for later use
-          this._conditionUUID = conditionUUID;
+    const { all: allWeather } = weather;
+    if (!allWeather) return "unparsed";
 
-          // store the observed date/time in our own format
-          this.generateWeatherStationTimeData(weather.current?.dateTime[1] ?? {});
+    this.parseStationLatLong(allWeather.location.name);
 
-          // time/date done so now fetch historical data
-          const observedDateTime: Date = this.observedDateTimeAtStation();
-          historicalData.fetchLastTwoYearsOfData(observedDateTime);
-          climateNormals.fetchClimateNormals(observedDateTime);
+    const conditionUUID = generateConditionsUUID(weather.current?.dateTime[1].timeStamp ?? "");
+    if (config.misc.rejectInHourConditionUpdates && conditionUUID === this._conditionUUID) {
+      logger.log("Rejecting in-hour conditions update as", conditionUUID, "was already parsed");
+      return "applied";
+    }
 
-          // get city name info
-          this._weatherStationCityName = allWeather.location.name.value;
+    this._conditionUUID = conditionUUID;
+    this.generateWeatherStationTimeData(weather.current?.dateTime[1] ?? {});
 
-          // get relevant conditions
-          this.parseRelevantConditions(weather.current);
+    const observedDateTime: Date = this.observedDateTimeAtStation();
+    historicalData.fetchLastTwoYearsOfData(observedDateTime);
+    climateNormals.fetchClimateNormals(observedDateTime);
 
-          // get sunrise/sunset info
-          this.parseSunriseSunset(allWeather.riseSet);
+    this._weatherStationCityName = allWeather.location.name.value;
+    this.parseRelevantConditions(weather.current);
+    this.parseSunriseSunset(allWeather.riseSet);
+    this.generateAlmanac(allWeather.almanac);
+    this.fillAlmanacNormalsFromRegional(
+      (allWeather as { regionalNormals?: RegionalNormalsFromFeed }).regionalNormals
+    );
+    this.generateWindchill(weather.current);
+    this.generateForecast(weather.weekly);
+    void this.getTempRecordsForDay();
 
-          // get the almanac data (normal, records, etc.)
-          this.generateAlmanac(allWeather.almanac);
+    this._conditionsFetchedAt = new Date().toISOString();
 
-          // calculate the windchill
-          this.generateWindchill(weather.current);
+    eventbus.emit(EVENT_BUS_MAIN_STATION_UPDATE_NEW_CONDITIONS, weather.current?.dateTime[0].timeStamp);
 
-          // generate the forecast
-          this.generateForecast(weather.weekly);
+    logger.log("Parsed new conditions with UUID of", conditionUUID);
+    return "applied";
+  }
 
-          // check if we've got an alternate record source
-          this.getTempRecordsForDay();
+  private async tryCitypageFetchCandidate(
+    fetchUrl: string,
+    applyGen: number,
+    signal: AbortSignal,
+    label: string
+  ): Promise<"ok" | "stale" | "continue"> {
+    try {
+      const resp = await axiosGetWithMscMirror(backendAxios, fetchUrl, { signal });
+      const applied = this.applyCitypageHttpResponse(resp, applyGen);
+      if (applied === "stale") return "stale";
+      if (applied === "applied") return "ok";
+      logger.warn(`${label}: response was not usable; trying next citypage source`);
+      return "continue";
+    } catch (err) {
+      if (isAxiosError(err) && err.code === "ERR_CANCELED") return "stale";
+      logger.warn(`${label}: fetch failed; trying next citypage source`, err);
+      return "continue";
+    }
+  }
 
-          // tell national stations what we're expecting
-          eventbus.emit(EVENT_BUS_MAIN_STATION_UPDATE_NEW_CONDITIONS, weather.current?.dateTime[0].timeStamp);
+  /**
+   * Citypage load order: AMQP URL (fast path) → hourly bucket URL (HPFX/Datamart-safe) → legacy HPFX `/xml/…_e.xml`.
+   */
+  private async runConditionsFetch(url?: string): Promise<void> {
+    this._conditionsFetchBusy = true;
+    const controller = new AbortController();
+    this._conditionsInFlightAbort = controller;
+    const { signal } = controller;
+    const applyGen = ++this._conditionsApplyGen;
+    const province = config.primaryLocation.province;
+    const stationId = config.primaryLocation.location;
 
-          logger.log("Parsed new conditions with UUID of", conditionUUID);
-        })
-        .catch((err) => {
-          logger.error("Unable to retrieve update to conditions from ECCC API", err);
-        });
+    try {
+      if (url !== undefined) {
+        const amqp = await this.tryCitypageFetchCandidate(
+          normalizeMscHttpUrl(url),
+          applyGen,
+          signal,
+          "AMQP citypage"
+        );
+        if (amqp === "ok" || amqp === "stale") return;
+      }
+
+      if (applyGen !== this._conditionsApplyGen) return;
+
+      const hourly = await GetWeatherFileFromECCC(province, stationId);
+      if (applyGen !== this._conditionsApplyGen) return;
+
+      if (hourly) {
+        const h = await this.tryCitypageFetchCandidate(hourly, applyGen, signal, "Hourly citypage (datamart resolve)");
+        if (h === "ok" || h === "stale") return;
+      }
+
+      if (applyGen !== this._conditionsApplyGen) return;
+
+      const legacy = legacyHpfxCitypageEnglishXmlUrl(province, stationId);
+      const leg = await this.tryCitypageFetchCandidate(legacy, applyGen, signal, "Legacy HPFX xml citypage");
+      if (leg === "ok" || leg === "stale") return;
+
+      logger.error("Unable to retrieve update to conditions from ECCC API (all citypage sources exhausted)");
+    } finally {
+      if (this._conditionsInFlightAbort === controller) {
+        this._conditionsInFlightAbort = null;
+      }
+      this._conditionsFetchBusy = false;
+      const pending = this._conditionsFetchPending;
+      this._conditionsFetchPending = null;
+      if (pending) {
+        void this.runConditionsFetch(pending.url);
+      }
+    }
   }
 
   private parseStationLatLong({ lat, lon }: { lat: string; lon: string }) {
-    // we get these in string format with compass directions so we need to convert slightly
-    // N is positive, S is negative
     if (lat.includes("N")) this.stationLatLong.lat = parseFloat(lat);
     else this.stationLatLong.lat = -parseFloat(lat);
 
-    // E is postive, W is negative
     if (lon.includes("E")) this.stationLatLong.long = parseFloat(lon);
     else this.stationLatLong.long = -parseFloat(lon);
   }
@@ -201,21 +319,14 @@ class CurrentConditions {
   private generateWeatherStationTimeData(date: any) {
     if (!date) return;
 
-    // convert the date string into the users local time to begin with
     const localDate = ecccDateStringToTSDate(date.textSummary);
 
-    // get the number of minutes behind that the local time is from UTC
     const offsetFromUTC = -localDate.getTimezoneOffset();
 
-    // get the number of minutes behind taht the station time is from utc
     const stationOffsetFromUTC = parseFloat(date.UTCOffset) * 60;
 
-    // now we can figure out the difference between these and use it on the ui
-    // timezones dont really exist in js so it'll really just end up being the local time
-    // with some minutes added onto it
     const stationOffsetMinutesFromLocal = stationOffsetFromUTC - offsetFromUTC;
 
-    // also store the actual timezone string for use on the ui
     this._weatherStationTimeData = {
       stationOffsetMinutesFromLocal,
       timezone: date.zone,
@@ -226,7 +337,6 @@ class CurrentConditions {
   private parseRelevantConditions(conditions: ECCCConditions) {
     if (!conditions) return;
 
-    // pull out the relevant info we want from eccc response
     const {
       condition,
       temperature: { units: temperatureUnits, value: temperatureValue },
@@ -240,14 +350,12 @@ class CurrentConditions {
       visibility,
     } = conditions;
 
-    // handle wind direction and visibility potentially being null
     const { value: windDirectionValue = null } = windDirection ?? {};
     const { value: visibilityValue = null, units: visibilityUnits = null } = visibility ?? {};
 
     let massagedVisibilityValue: number | string | null | undefined = visibilityValue;
     if (!isLooseNull(visibilityValue)) massagedVisibilityValue = Number(visibilityValue);
 
-    // store it to our conditions
     this._conditions = {
       condition,
       abbreviatedCondition: harshTruncateConditions(condition),
@@ -277,48 +385,74 @@ class CurrentConditions {
   private parseSunriseSunset(riseSet: ECCCSunRiseSet) {
     if (!riseSet) return;
 
-    // get the utc sunrise time
     const sunrise: ECCCDateTime = riseSet.dateTime.find(
       (dateTime: ECCCDateTime) => dateTime.name === "sunrise" && dateTime.zone !== "UTC"
     );
     if (sunrise) this._sunRiseSet.rise = ecccDateStringToTSDate(sunrise.textSummary).toISOString();
 
-    // get the utc sunset time
     const sunset: ECCCDateTime = riseSet.dateTime.find(
       (dateTime: ECCCDateTime) => dateTime.name === "sunset" && dateTime.zone !== "UTC"
     );
     if (sunset) this._sunRiseSet.set = ecccDateStringToTSDate(sunset.textSummary).toISOString();
   }
 
-  private generateAlmanac(almanac: ECCCAlmanac) {
-    // TODO: fetch records from alternate source
+  private mergedAlmanacTemperatures() {
+    return {
+      ...this._almanac.temperatures,
+      lastYearMin: historicalData.lastYearTemperatures().min,
+      lastYearMax: historicalData.lastYearTemperatures().max,
+    };
+  }
 
-    // get the extreme min temp
+  private generateAlmanac(almanac: ECCCAlmanac | null | undefined) {
+    const temps: ECCCAlmanacTemp[] = !almanac?.temperature
+      ? []
+      : Array.isArray(almanac.temperature)
+        ? almanac.temperature
+        : [almanac.temperature];
+
     const retrieveAlmanacTemp = (tempClass: string, parseYear: boolean = true) => {
-      if (!almanac) return null;
+      if (!temps.length || !tempClass) return null;
 
-      // fetch from the almanac temperatures list
-      const extremeTemp: ECCCAlmanacTemp = almanac.temperature.find(
-        (temp: ECCCAlmanacTemp) => temp.class === tempClass
-      );
+      const entry = temps.find((temp: ECCCAlmanacTemp) => temp.class === tempClass);
+      if (!entry) return null;
 
-      // if nothing return null
-      if (!tempClass) return null;
+      const num = Number(entry.value);
+      if (!Number.isFinite(num)) return null;
 
-      // otherwise parse it out and return
-      const { value, year, units } = extremeTemp;
-      return { value: Number(value), year: parseYear ? parseInt(year) : undefined, unit: units };
+      const y = entry.year != null ? parseInt(String(entry.year), 10) : NaN;
+      return {
+        value: num,
+        year: parseYear && Number.isFinite(y) ? y : undefined,
+        unit: entry.units ?? "C",
+      };
     };
 
-    // extreme min/max
     this._almanac.temperatures.extremeMin = retrieveAlmanacTemp("extremeMin");
     this._almanac.temperatures.extremeMax = retrieveAlmanacTemp("extremeMax");
 
-    // normal min/max
     this._almanac.temperatures.normalMin = retrieveAlmanacTemp("normalMin", false);
     this._almanac.temperatures.normalMax = retrieveAlmanacTemp("normalMax", false);
+  }
 
-    // last year min/max is done at request time for observed to make sure we have that data
+  private fillAlmanacNormalsFromRegional(regionalNormals: RegionalNormalsFromFeed | null | undefined) {
+    if (!regionalNormals) return;
+    if (this._almanac.temperatures.normalMin != null && this._almanac.temperatures.normalMax != null) return;
+
+    const raw = regionalNormals.temperature;
+    const list: ECCCAlmanacTemp[] = !raw ? [] : Array.isArray(raw) ? raw : [raw];
+
+    for (const t of list) {
+      const v = Number(t.value);
+      if (!Number.isFinite(v)) continue;
+      const unit = t.units ?? "C";
+      if (t.class === "low" && this._almanac.temperatures.normalMin == null) {
+        this._almanac.temperatures.normalMin = { value: v, unit };
+      }
+      if (t.class === "high" && this._almanac.temperatures.normalMax == null) {
+        this._almanac.temperatures.normalMax = { value: v, unit };
+      }
+    }
   }
 
   private generateWindchill(conditions: ECCCConditions) {
@@ -363,15 +497,15 @@ class CurrentConditions {
   private async getTempRecordsForDay() {
     if (!config.misc.alternateRecordsSource?.length) return;
 
-    // get the temp record if there are any
     const tempRecord = await getTempRecordForDate(config.misc.alternateRecordsSource, this.observedDateTimeAtStation());
     if (!tempRecord) return;
 
-    // update hi/lo values
-    if (tempRecord.hi)
+    if (tempRecord.hi) {
       this._almanac.temperatures.extremeMax = { value: tempRecord.hi.value, year: tempRecord.hi.year, unit: "C" };
-    if (tempRecord.lo)
+    }
+    if (tempRecord.lo) {
       this._almanac.temperatures.extremeMin = { value: tempRecord.lo.value, year: tempRecord.lo.year, unit: "C" };
+    }
   }
 
   public observed() {
@@ -380,14 +514,11 @@ class CurrentConditions {
       city: this._weatherStationCityName,
       stationTime: this._weatherStationTimeData,
       stationID: this._weatherStationID,
+      fetchedAt: this._conditionsFetchedAt,
       observed: { ...this._conditions, windchill: this._windchill },
       almanac: {
         ...this._almanac,
-        temperatures: {
-          ...this._almanac.temperatures,
-          lastYearMin: historicalData.lastYearTemperatures().min,
-          lastYearMax: historicalData.lastYearTemperatures().max,
-        },
+        temperatures: this.mergedAlmanacTemperatures(),
         sunRiseSet: this._sunRiseSet,
       },
       forecast: this._forecast,
@@ -410,7 +541,11 @@ class CurrentConditions {
       city: this._weatherStationCityName,
       stationTime: this._weatherStationTimeData,
       stationID: this._weatherStationID,
-      almanac: { ...this._almanac, sunRiseSet: this._sunRiseSet },
+      almanac: {
+        ...this._almanac,
+        temperatures: this.mergedAlmanacTemperatures(),
+        sunRiseSet: this._sunRiseSet,
+      },
     };
   }
 

--- a/src/lib/eccc/datamart.ts
+++ b/src/lib/eccc/datamart.ts
@@ -1,58 +1,152 @@
 import { subHours } from "date-fns";
+import { isAxiosError } from "axios";
 import axios from "lib/backendAxios";
 import Logger from "lib/logger";
+import {
+  rwcDatamartHourlyDirExtraRetries,
+  rwcDatamartHourlyDirRetryDelayMs,
+} from "consts/reliability.consts";
+import {
+  axiosGetWithMscMirrorResolved,
+  axiosHeadWithMscMirror,
+  MSC_HPFX_ORIGIN,
+} from "lib/eccc/mscHttpMirror";
 
 const logger = new Logger("Datamart");
-async function GetWeatherFileFromECCC(province: string, stationID: string): Promise<string | null> {
-  // ECCC has massively changed the format of the data structure now so as of June 2025, the new format is as follows:
-  // https://dd.weather.gc.ca/citypage_weather/PROVINCE/UTC_HOUR/TIMEDATE_STAMP_MSC_CitypageWeather_STATION_CODE_en.xml
-  // https://dd.weather.gc.ca/citypage_weather/MB/18/20250627T180206.714Z_MSC_CitypageWeather_s0000193_en.xml
 
-  // as of October 2025 there is now `/today` after the base url https://dd.weather.gc.ca/today/
-
-  // due to this, what we're gonna do is get the current UTC hour, or the previous UTC hour
-  const currentUTCHour = new Date().getUTCHours();
-  const previousUTCHour = subHours(new Date(), 1).getUTCHours();
-
-  const parser = async (utcHour: number) => {
-    const paddedUTCHour = `${utcHour}`.padStart(2, "0");
-    const baseURL = `https://dd.weather.gc.ca/today/citypage_weather/${province}/${paddedUTCHour}/`;
-    try {
-      // first we check if the directory exists
-      const resp = await axios.get(baseURL);
-      const rawData = resp && (resp.data as string);
-      if (!rawData) return null;
-
-      const data = rawData as string;
-      // once we know it does exist we need to parse out the directory structure it gives us
-      // const regexPattern = ;
-      const regex = RegExp(`href="([^"]*MSC_CitypageWeather_${stationID}_en\.xml)"`, "gi");
-
-      // see if we get a match in here
-      const matches = [...data.matchAll(regex)].map((m) => m[1]);
-      if (matches) {
-        const latest = matches.sort().at(-1);
-
-        // we need to make sure we get the lastest
-        // as for some reason old data can end up in the new hours directory
-        if (latest) return `${baseURL}${latest}`;
-      }
-
-      // otherwise we found no data for this station
-      return null;
-    } catch (err) {
-      logger.error(province, paddedUTCHour, "failed to fetch data");
-    }
-
-    // final fallback for return value
-    return null;
-  };
-
-  // we can't async/await a foreach so we've gotta do this manually
-  const currentResult = await parser(currentUTCHour);
-  if (currentResult) return currentResult;
-
-  return await parser(previousUTCHour);
+function formatDatamartFetchError(err: unknown): string {
+  if (isAxiosError(err)) {
+    const status = err.response?.status;
+    const url = err.config?.url ?? "unknown URL";
+    if (status) return `${status} ${url}`;
+    return err.message || "axios error";
+  }
+  if (err instanceof Error) return err.message;
+  return String(err);
 }
 
-export { GetWeatherFileFromECCC };
+/**
+ * Citypage buckets under `/today/citypage_weather/…/<UTC hour two digits>/` can lag; try several hours.
+ * (Datamart mirror: https://dd.weather.gc.ca/… — listing + file must use the same host that served the index.)
+ */
+const CITYPAGE_UTC_HOUR_FALLBACKS = 8;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * True when the hourly directory request might succeed after a short wait (new hour not published yet, transient upstream).
+ */
+function isMscHourlyDirectoryMaybeNotPublished(err: unknown): boolean {
+  if (!isAxiosError(err)) return true;
+  if (err.code === "ERR_CANCELED") return false;
+  const s = err.response?.status;
+  if (s == null) return true;
+  if (s === 404 || s === 403) return true;
+  if (s >= 500) return true;
+  if (s === 408 || s === 429) return true;
+  return false;
+}
+
+function englishCitypageHrefPattern(stationID: string): RegExp {
+  const escaped = stationID.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`href="([^"]*MSC_CitypageWeather_${escaped}_en\\.xml)"`, "gi");
+}
+
+/**
+ * Resolve the latest English citypage XML URL for a station.
+ * Uses the hourly directory layout on MSC mirrors (HPFX / Datamart).
+ */
+async function GetWeatherFileFromECCC(province: string, stationID: string): Promise<string | null> {
+  const utcHoursToTry = Array.from({ length: CITYPAGE_UTC_HOUR_FALLBACKS }, (_, i) =>
+    subHours(new Date(), i).getUTCHours()
+  );
+
+  const regex = englishCitypageHrefPattern(stationID);
+  const extraDirRetries = rwcDatamartHourlyDirExtraRetries();
+  const dirRetryDelayMs = rwcDatamartHourlyDirRetryDelayMs();
+
+  hourLoop: for (let hourIx = 0; hourIx < utcHoursToTry.length; hourIx++) {
+    const utcHour = utcHoursToTry[hourIx]!;
+    const paddedUTCHour = `${utcHour}`.padStart(2, "0");
+    const baseURL = `${MSC_HPFX_ORIGIN}/today/citypage_weather/${encodeURIComponent(province)}/${paddedUTCHour}/`;
+
+    const maxDirAttempts = hourIx === 0 ? 1 + extraDirRetries : 1;
+
+    for (let attempt = 0; attempt < maxDirAttempts; attempt++) {
+      if (attempt > 0) {
+        const jitter = Math.floor(Math.random() * 2000);
+        await sleep(dirRetryDelayMs + jitter);
+      }
+
+      let html: string | undefined;
+      let directoryResolvedUrl: string | undefined;
+      let lastDirErr: unknown;
+
+      try {
+        const { response, resolvedUrl } = await axiosGetWithMscMirrorResolved(axios, baseURL);
+        directoryResolvedUrl = resolvedUrl;
+        html = response.data as string;
+        lastDirErr = undefined;
+      } catch (err) {
+        lastDirErr = err;
+        if (attempt < maxDirAttempts - 1 && isMscHourlyDirectoryMaybeNotPublished(err)) {
+          continue;
+        }
+        logger.warn(
+          `Citypage hourly directory ${province}/${paddedUTCHour}Z listing failed (${formatDatamartFetchError(lastDirErr)})`
+        );
+        continue hourLoop;
+      }
+
+      if (!html) {
+        if (hourIx === 0 && attempt < maxDirAttempts - 1) {
+          continue;
+        }
+        logger.warn(`Citypage hourly directory ${province}/${paddedUTCHour}Z: empty listing body`);
+        continue hourLoop;
+      }
+      if (!directoryResolvedUrl) {
+        continue hourLoop;
+      }
+
+      const hrefs = [...html.matchAll(regex)].map((m) => m[1]);
+      const unique = [...new Set(hrefs)];
+
+      if (!unique.length) {
+        if (hourIx === 0 && attempt < maxDirAttempts - 1) {
+          continue;
+        }
+        continue hourLoop;
+      }
+
+      const newestFirst = unique.sort().reverse();
+      const dirBase = directoryResolvedUrl.endsWith("/") ? directoryResolvedUrl : `${directoryResolvedUrl}/`;
+
+      for (const file of newestFirst) {
+        const fileUrl = `${dirBase}${file}`;
+        try {
+          await axiosHeadWithMscMirror(axios, fileUrl);
+          return fileUrl;
+        } catch {
+          /* older or phantom listing row; try next timestamp */
+        }
+      }
+
+      continue hourLoop;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Legacy stable English citypage path (HPFX). Datamart does not mirror `/xml/…`; use only as a last-resort
+ * fallback when hourly resolution fails. {@link axiosGetWithMscMirror} still tries HPFX before Datamart.
+ */
+function legacyHpfxCitypageEnglishXmlUrl(province: string, stationID: string): string {
+  return `${MSC_HPFX_ORIGIN}/today/citypage_weather/xml/${encodeURIComponent(province)}/${encodeURIComponent(stationID)}_e.xml`;
+}
+
+export { GetWeatherFileFromECCC, legacyHpfxCitypageEnglishXmlUrl };

--- a/src/lib/eccc/mscHttpMirror.ts
+++ b/src/lib/eccc/mscHttpMirror.ts
@@ -1,0 +1,213 @@
+/**
+ * MSC Datamart HTTP mirrors: high-throughput HPFX (primary) vs redundant Datamart (fallback).
+ * See https://hpfx.collab.science.gc.ca/ — long-term, consider Sarracenia/AMQP delivery:
+ * https://metpx.github.io/sarracenia/How2Guides/subscriber.html
+ */
+import { AxiosInstance, AxiosResponse, isAxiosError } from "axios";
+import type { RwcAxiosRequestConfig } from "types/rwcAxiosConfig";
+import {
+  rwcHttpRetryBackoffMaxMs,
+  rwcHttpRetryBackoffMinMs,
+  rwcHttpRetryCount,
+} from "consts/reliability.consts";
+import {
+  upstreamCircuitAllowRequest,
+  upstreamCircuitRecordFailureFromError,
+  upstreamCircuitRecordSuccess,
+} from "lib/reliability/upstreamCircuit";
+
+export const MSC_HPFX_ORIGIN = "https://hpfx.collab.science.gc.ca";
+export const MSC_DATAMART_ORIGIN = "https://dd.weather.gc.ca";
+
+/** Normalize legacy http://dd.weather.gc.ca links to https for consistent mirror swaps. */
+export function normalizeMscHttpUrl(url: string): string {
+  return url.replace(/^http:\/\/dd\.weather\.gc\.ca\b/i, `${MSC_DATAMART_ORIGIN}`);
+}
+
+/**
+ * For dd.weather.gc.ca or hpfx.collab.science.gc.ca URLs, return [try first, try second]:
+ * always prefer HPFX first, then Datamart. Other hosts are returned unchanged (single attempt).
+ */
+export function mscMirrorTryOrder(url: string): string[] {
+  const normalized = normalizeMscHttpUrl(url);
+  let u: URL;
+  try {
+    u = new URL(normalized);
+  } catch {
+    return [url];
+  }
+
+  if (u.hostname === "hpfx.collab.science.gc.ca") {
+    const datamart = `${MSC_DATAMART_ORIGIN}${u.pathname}${u.search}${u.hash}`;
+    const pair = normalized === datamart ? [normalized] : [normalized, datamart];
+    return process.env.RWC_MSC_TRY_DATAMART_FIRST === "1" ? [...pair].reverse() : pair;
+  }
+  if (u.hostname === "dd.weather.gc.ca") {
+    const hpfx = `${MSC_HPFX_ORIGIN}${u.pathname}${u.search}${u.hash}`;
+    const pair = hpfx === normalized ? [normalized] : [hpfx, normalized];
+    return process.env.RWC_MSC_TRY_DATAMART_FIRST === "1" ? [...pair].reverse() : pair;
+  }
+  return [normalized];
+}
+
+/** After an error on one mirror host, try the paired HPFX/Datamart URL (same wave). */
+export function shouldTryNextMscMirrorHost(err: unknown): boolean {
+  if (!isAxiosError(err)) return true;
+  if (err.code === "ERR_CANCELED") return false;
+  const status = err.response?.status;
+  if (status == null) return true;
+  if (status === 404 || status === 403) return true;
+  if (status >= 500) return true;
+  if (status === 408 || status === 429) return true;
+  return false;
+}
+
+/** Start another retry wave (sleep + full candidate list) — not for terminal 4xx such as 404 after both mirrors. */
+export function shouldStartAnotherMscMirrorWave(err: unknown): boolean {
+  if (!isAxiosError(err)) return true;
+  if (err.code === "ERR_CANCELED") return false;
+  const status = err.response?.status;
+  if (status == null) return true;
+  if (status >= 500) return true;
+  if (status === 408 || status === 429) return true;
+  return false;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function jitterBackoffMs(attemptIndex: number): number {
+  const minMs = rwcHttpRetryBackoffMinMs();
+  const maxMs = rwcHttpRetryBackoffMaxMs();
+  const cap = Math.min(maxMs, minMs * 2 ** attemptIndex);
+  return minMs + Math.random() * Math.max(0, cap - minMs);
+}
+
+function defaultMscUpstreamMeta(url: string): { feed: string; key: string } {
+  try {
+    return { feed: "msc-http", key: new URL(url).pathname.slice(0, 120) };
+  } catch {
+    return { feed: "msc-http", key: url.slice(0, 120) };
+  }
+}
+
+/** GET with HPFX-first / Datamart-failover for MSC mirror host pairs, bounded retries, circuit breaker. */
+export async function axiosGetWithMscMirror<T = unknown>(
+  client: AxiosInstance,
+  url: string,
+  config?: RwcAxiosRequestConfig
+): Promise<AxiosResponse<T>> {
+  const maxExtraAttempts = rwcHttpRetryCount();
+  const candidates = [...new Set(mscMirrorTryOrder(url))];
+  let lastError: unknown;
+
+  for (let wave = 0; wave <= maxExtraAttempts; wave++) {
+    if (wave > 0) {
+      await sleep(jitterBackoffMs(wave - 1));
+    }
+    for (let i = 0; i < candidates.length; i++) {
+      const u = candidates[i];
+      if (!upstreamCircuitAllowRequest(u)) {
+        lastError = new Error(`MSC upstream in cool-off: ${u}`);
+        continue;
+      }
+      try {
+        const merged: RwcAxiosRequestConfig = {
+          ...config,
+          rwcUpstream: config?.rwcUpstream ?? defaultMscUpstreamMeta(u),
+        };
+        const response = await client.get<T>(u, merged);
+        upstreamCircuitRecordSuccess(u);
+        return response;
+      } catch (err) {
+        lastError = err;
+        upstreamCircuitRecordFailureFromError(u, err);
+        if (i === candidates.length - 1) break;
+        if (!shouldTryNextMscMirrorHost(err)) break;
+      }
+    }
+    if (lastError != null && !shouldStartAnotherMscMirrorWave(lastError)) break;
+  }
+  throw lastError;
+}
+
+export async function axiosGetWithMscMirrorResolved<T = unknown>(
+  client: AxiosInstance,
+  url: string,
+  config?: RwcAxiosRequestConfig
+): Promise<{ response: AxiosResponse<T>; resolvedUrl: string }> {
+  const maxExtraAttempts = rwcHttpRetryCount();
+  const candidates = [...new Set(mscMirrorTryOrder(url))];
+  let lastError: unknown;
+
+  for (let wave = 0; wave <= maxExtraAttempts; wave++) {
+    if (wave > 0) {
+      await sleep(jitterBackoffMs(wave - 1));
+    }
+    for (let i = 0; i < candidates.length; i++) {
+      const u = candidates[i];
+      if (!upstreamCircuitAllowRequest(u)) {
+        lastError = new Error(`MSC upstream in cool-off: ${u}`);
+        continue;
+      }
+      try {
+        const merged: RwcAxiosRequestConfig = {
+          ...config,
+          rwcUpstream: config?.rwcUpstream ?? defaultMscUpstreamMeta(u),
+        };
+        const response = await client.get<T>(u, merged);
+        upstreamCircuitRecordSuccess(u);
+        return { response, resolvedUrl: u };
+      } catch (err) {
+        lastError = err;
+        upstreamCircuitRecordFailureFromError(u, err);
+        if (i === candidates.length - 1) break;
+        if (!shouldTryNextMscMirrorHost(err)) break;
+      }
+    }
+    if (lastError != null && !shouldStartAnotherMscMirrorWave(lastError)) break;
+  }
+  throw lastError;
+}
+
+export async function axiosHeadWithMscMirror(
+  client: AxiosInstance,
+  url: string,
+  config?: RwcAxiosRequestConfig
+): Promise<AxiosResponse<unknown>> {
+  const maxExtraAttempts = rwcHttpRetryCount();
+  const candidates = [...new Set(mscMirrorTryOrder(url))];
+  let lastError: unknown;
+
+  for (let wave = 0; wave <= maxExtraAttempts; wave++) {
+    if (wave > 0) {
+      await sleep(jitterBackoffMs(wave - 1));
+    }
+    for (let i = 0; i < candidates.length; i++) {
+      const u = candidates[i];
+      if (!upstreamCircuitAllowRequest(u)) {
+        lastError = new Error(`MSC upstream in cool-off: ${u}`);
+        continue;
+      }
+      try {
+        const headConfig: RwcAxiosRequestConfig = {
+          ...config,
+          method: "HEAD",
+          url: u,
+          rwcUpstream: config?.rwcUpstream ?? { feed: "msc-head", key: new URL(u).pathname.slice(0, 120) },
+        };
+        const response = await client.request<unknown>(headConfig);
+        upstreamCircuitRecordSuccess(u);
+        return response;
+      } catch (err) {
+        lastError = err;
+        upstreamCircuitRecordFailureFromError(u, err);
+        if (i === candidates.length - 1) break;
+        if (!shouldTryNextMscMirrorHost(err)) break;
+      }
+    }
+    if (lastError != null && !shouldStartAnotherMscMirrorWave(lastError)) break;
+  }
+  throw lastError;
+}

--- a/src/lib/reliability/upstreamCircuit.ts
+++ b/src/lib/reliability/upstreamCircuit.ts
@@ -1,0 +1,82 @@
+import { isAxiosError } from "axios";
+import { rwcCircuitCoolOffMs, rwcCircuitFailureThreshold } from "consts/reliability.consts";
+
+export type UpstreamCircuitSnapshot = Record<
+  string,
+  {
+    consecutiveFailures: number;
+    coolOffUntilMs: number | null;
+  }
+>;
+
+const failures = new Map<string, number>();
+const coolUntil = new Map<string, number>();
+
+function hostKey(urlOrHost: string): string {
+  if (urlOrHost.includes("://")) {
+    try {
+      return new URL(urlOrHost).hostname.toLowerCase();
+    } catch {
+      return urlOrHost.toLowerCase();
+    }
+  }
+  return urlOrHost.toLowerCase();
+}
+
+/** Returns false when host is in cool-off — caller should skip the upstream request. */
+export function upstreamCircuitAllowRequest(url: string): boolean {
+  const h = hostKey(url);
+  const until = coolUntil.get(h);
+  if (until != null && Date.now() < until) return false;
+  if (until != null && Date.now() >= until) {
+    coolUntil.delete(h);
+    failures.set(h, 0);
+  }
+  return true;
+}
+
+export function upstreamCircuitRecordSuccess(url: string): void {
+  const h = hostKey(url);
+  failures.set(h, 0);
+  coolUntil.delete(h);
+}
+
+export function upstreamCircuitRecordFailure(url: string): void {
+  const h = hostKey(url);
+  const k = rwcCircuitFailureThreshold();
+  const n = (failures.get(h) ?? 0) + 1;
+  failures.set(h, n);
+  if (n >= k) {
+    coolUntil.set(h, Date.now() + rwcCircuitCoolOffMs());
+    failures.set(h, 0);
+  }
+}
+
+/** Count toward circuit only for overload / server / network (not 404 / generic 4xx). */
+export function upstreamCircuitRecordFailureFromError(url: string, err: unknown): void {
+  if (isAxiosError(err)) {
+    if (err.code === "ERR_CANCELED") return;
+    const s = err.response?.status;
+    if (s === 404) return;
+    if (s != null && s >= 400 && s < 500 && s !== 408 && s !== 429) return;
+  }
+  upstreamCircuitRecordFailure(url);
+}
+
+export function getUpstreamCircuitSnapshot(): UpstreamCircuitSnapshot {
+  const out: UpstreamCircuitSnapshot = {};
+  const hosts = new Set([...failures.keys(), ...coolUntil.keys()]);
+  for (const h of hosts) {
+    out[h] = {
+      consecutiveFailures: failures.get(h) ?? 0,
+      coolOffUntilMs: coolUntil.get(h) ?? null,
+    };
+  }
+  return out;
+}
+
+/** Test isolation */
+export function resetUpstreamCircuitsForTests(): void {
+  failures.clear();
+  coolUntil.clear();
+}

--- a/src/types/condition.types.ts
+++ b/src/types/condition.types.ts
@@ -86,6 +86,8 @@ export type WeatherStation = {
   city: string;
   stationTime: WeatherStationTimeData;
   stationID: string;
+  /** ISO time of last successful citypage parse (null before first fetch). */
+  fetchedAt?: string | null;
   observed: ObservedConditions & { windchill: number | null };
   almanac: Almanac & { sunRiseSet: SunRiseSet };
   forecast: WeekForecast;

--- a/src/types/rwcAxiosConfig.ts
+++ b/src/types/rwcAxiosConfig.ts
@@ -1,0 +1,8 @@
+import type { AxiosRequestConfig } from "axios";
+
+export type RwcUpstreamMeta = { feed: string; key?: string };
+
+/** Axios request config plus optional upstream logging metadata (no secrets). */
+export type RwcAxiosRequestConfig<D = unknown> = AxiosRequestConfig<D> & {
+  rwcUpstream?: RwcUpstreamMeta;
+};


### PR DESCRIPTION
## Purpose

Production-grade **citypage XML** fetching for MSC’s hourly bucket layout and **HPFX / Datamart** mirrors. Intended to merge **independently** of [#1099](https://github.com/Forceh91/retro-env-can-weather-chan/pull/1099) (historical / normals / province precip): **no files overlap**, so either PR can land first.

## What changed

| Area | Notes |
|------|--------|
| **`datamart.ts`** | Multi-hour UTC directory fallbacks, **same-host** listing → file URLs, **HEAD** checks for phantom rows, env-tuned publication-lag retries (`RWC_DATAMART_HOURLY_DIR_*`). |
| **`mscHttpMirror.ts`** | HPFX ↔ Datamart failover, bounded retries (`RWC_HTTP_RETRY_*`), per-host circuit cool-off (`RWC_CIRCUIT_*`), optional `RWC_MSC_TRY_DATAMART_FIRST=1`. |
| **`conditions.ts`** | Coalesced pipeline: **AMQP URL** → **hourly resolve** → **legacy HPFX `/xml/…_e.xml`**; `AbortSignal` when superseded; optional **stale HTTP poll** (`RWC_CITYPAGE_STALE_*`, disable with `RWC_CITYPAGE_STALE_FALLBACK_DISABLED=1`). |
| **`backendAxios.ts`** | Sensible timeout + redirect cap via new `http.consts`. |
| **`reliability.consts.ts`** | Shared env helpers (includes LKG / disk knobs unused here but harmless for follow-ups). |
| **API** | `observed()` includes optional `fetchedAt` (ISO). |

## Parallel merge with #1099

- This branch does **not** add `fetchErrors.ts`; `datamart` uses a small local error formatter so there is **no dependency** on #1099. After both merge, you can optionally dedupe to `formatFetchError` from #1099.

## Tests

`yarn test` — all green on this branch.

---

Happy to split (e.g. mirror layer only) if you want smaller review chunks.